### PR TITLE
fix unstable `QueryClient` and configs in React "Getting Started" guide

### DIFF
--- a/docs/pages/react/getting-started.mdx
+++ b/docs/pages/react/getting-started.mdx
@@ -36,27 +36,27 @@ import { WagmiProvider, createConfig, http } from "wagmi"
 import { sepolia, arbitrum } from "wagmi/chains"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
-export default function Providers({ children }: { children: React.ReactNode }) {  
-  const wagmiConfig = createConfig({
-    chains: [arbitrum, sepolia],
-    transports: {
-      [arbitrum.id]: http(),
-      [sepolia.id]: http(),
-    },
-  })
-  const zdConfig = createZdConfig({
-    chains: [arbitrum, sepolia],
-    transports: {
-      [arbitrum.id]: http(),
-      [sepolia.id]: http(),
-    },
-    projectIds: {
-      [arbitrum.id]: ZERODEV_ARB_PROJECT_ID,
-      [sepolia.id]: ZERODEV_SEPOLIA_PROJECT_ID
-    } 
-  })
-  const queryClient = new QueryClient()
+const wagmiConfig = createConfig({
+  chains: [arbitrum, sepolia],
+  transports: {
+    [arbitrum.id]: http(),
+    [sepolia.id]: http(),
+  },
+})
+const zdConfig = createZdConfig({
+  chains: [arbitrum, sepolia],
+  transports: {
+    [arbitrum.id]: http(),
+    [sepolia.id]: http(),
+  },
+  projectIds: {
+    [arbitrum.id]: ZERODEV_ARB_PROJECT_ID,
+    [sepolia.id]: ZERODEV_SEPOLIA_PROJECT_ID
+  } 
+})
+const queryClient = new QueryClient()
 
+export default function Providers({ children }: { children: React.ReactNode }) {  
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
This PR fixes incorrect code in `@zerodev/waas`'s "Getting Started" guide. The configs and the `QueryClient` should be instantiated once,[^1][^2] rather than on every render. 

[^1]: https://tanstack.com/query/latest/docs/eslint/stable-query-client
[^2]: https://wagmi.sh/react/getting-started#wrap-app-in-context-provider