### PR TITLE
Fix type-error in the `quickstart.mdx` 

### DIFF
--- a/docs/pages/sdk/getting-started/quickstart.mdx
+++ b/docs/pages/sdk/getting-started/quickstart.mdx
@@ -63,6 +63,7 @@ const main = async () => {
   // Construct a public client
   const publicClient = createPublicClient({
     transport: http(BUNDLER_RPC),
+    chain
   })
 
   // Construct a validator


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0f37a8bf-aefd-4194-bcf6-574558d7bbfa)


```diff
// Construct a public client
const publicClient = createPublicClient({
  transport: http(BUNDLER_RPC),
+  chain
})
```

with this change, the error above image is resolved

env
- node v20.17.0
- `npx ts-node --version` v10.9.2