### PR TITLE
docs: typo fix Update 3074-pitfalls.mdx

### DIFF
--- a/docs/pages/blog/3074-pitfalls.mdx
+++ b/docs/pages/blog/3074-pitfalls.mdx
@@ -37,7 +37,7 @@ A mempool is a network of relayers that shares transactions with one another.  A
 
 In Ethereum, about 90% of transactions go into the public mempool, which is permissionless; the rest go into various private and permissioned mempools such as Flashbots Protect, usually for MEV protection.
 
-While permissioned mempools have an important role to play, it’s crucial that a permissionless mempool *exists*.  To see why, consider the fact that currently [over 35% of MEV-Boost relays censor transactions](https://www.mevwatch.info/).  Since permissioned mempools consist of a known set of nodes, they are particular susceptible to government pressures.  A permissionless mempool serves as the last line of defense against censorship, ensuring that transactions can be included even in the most adversarial scenarios.
+While permissioned mempools have an important role to play, it’s crucial that a permissionless mempool *exists*.  To see why, consider the fact that currently [over 35% of MEV-Boost relays censor transactions](https://www.mevwatch.info/).  Since permissioned mempools consist of a known set of nodes, they are particularly susceptible to government pressures.  A permissionless mempool serves as the last line of defense against censorship, ensuring that transactions can be included even in the most adversarial scenarios.
 
 If we are not careful, however, **EIP-3074 mempools may become exclusively permissioned**.
 


### PR DESCRIPTION
**"particular susceptible"** — the correct phrase should be **"particularly susceptible"**.

This is an error in the use of the adjective. The word "particular" should be replaced with "particularly" in this context.