### PR TITLE
docs: Fix typo in "Reading CAB" section

### DIFF
--- a/docs/pages/magic-account/usage/chain-abstraction.mdx
+++ b/docs/pages/magic-account/usage/chain-abstraction.mdx
@@ -126,7 +126,7 @@ When a token is chain-abstracted, it actually [sits in a vault](/sdk/faqs/why-ch
 
 Instead, use a helper function to read the CAB.
 
-### Wamgi
+### Wagmi
 
 ```tsx
 import { useReadCab } from "@zerodev/magic-account"


### PR DESCRIPTION
I noticed a typo in the "Reading CAB" section—"Wamgi" should be "Wagmi." This PR fixes that.