### PR TITLE
add the kernelVersion to the signerToEcdsaValidator function in tutorial.mdx

### DIFF
--- a/docs/pages/sdk/getting-started/tutorial.mdx
+++ b/docs/pages/sdk/getting-started/tutorial.mdx
@@ -85,7 +85,7 @@ const main = async () => {
   const ecdsaValidator = await signerToEcdsaValidator(publicClient, { // [!code focus]
     signer,  // [!code focus]
     entryPoint,  // [!code focus]
-    kernelVersion, // [!code focus]
+    kernelVersion: KERNEL_V3_1, // [!code focus]
   })  // [!code focus]
 }
 ```


### PR DESCRIPTION
just a small change, but without that you would receive an error.