### PR TITLE
docs(omni-sdk): flag CSPRNG failure mode on Signer.generate()

### DIFF
--- a/docs/pages/get-started/sdks/client-side/android.mdx
+++ b/docs/pages/get-started/sdks/client-side/android.mdx
@@ -46,7 +46,7 @@ Context.create(
 }
 ```
 
-`Signer.generate()` is useful for demos when you don't need to reuse a key. All handles implement `AutoCloseable` — use Kotlin's `use { }` to release native resources deterministically.
+`Signer.generate()` is useful for demos when you don't need to reuse a key. It requires a working OS CSPRNG; on hardened sandboxes where `getrandom(2)` is blocked the call throws rather than producing a weak key, so production paths in those environments should pass a real key via `Signer.local(privateKey)`. All handles implement `AutoCloseable` — use Kotlin's `use { }` to release native resources deterministically.
 
 ## Example — sponsored UserOp
 

--- a/docs/pages/get-started/sdks/client-side/ios.mdx
+++ b/docs/pages/get-started/sdks/client-side/ios.mdx
@@ -42,7 +42,7 @@ let signer = try Signer.local(privateKey: pk)
 let account = try ctx.newAccount(signer: signer, version: .v3_3)
 ```
 
-`Signer.generate()` is useful for demos when you don't need to reuse a key.
+`Signer.generate()` is useful for demos when you don't need to reuse a key. It requires a working OS CSPRNG; on hardened sandboxes where `getrandom(2)` is blocked the call returns an error rather than producing a weak key, so production paths in those environments should pass a real key via `Signer.local(privateKey:)`.
 
 ## Example — sponsored UserOp
 

--- a/docs/pages/get-started/sdks/server-side/go.mdx
+++ b/docs/pages/get-started/sdks/server-side/go.mdx
@@ -50,7 +50,7 @@ if err != nil { panic(err) }
 defer account.Close()
 ```
 
-`aa.GenerateSigner()` is useful for demos when you don't need to reuse a key.
+`aa.GenerateSigner()` is useful for demos when you don't need to reuse a key. It requires a working OS CSPRNG; on hardened sandboxes where `getrandom(2)` is blocked the call returns an error rather than producing a weak key, so production paths in those environments should pass a real key via `aa.LocalSigner(pk)`.
 
 ## Example — sponsored UserOp
 

--- a/docs/pages/get-started/sdks/server-side/python.mdx
+++ b/docs/pages/get-started/sdks/server-side/python.mdx
@@ -36,7 +36,7 @@ with Context(
             pass
 ```
 
-`Signer.generate()` is useful for demos when you don't need to reuse a key. Use `with` blocks (or call `.close()`) to release native resources.
+`Signer.generate()` is useful for demos when you don't need to reuse a key. It requires a working OS CSPRNG; on hardened sandboxes where `getrandom(2)` is blocked the call raises rather than producing a weak key, so production paths in those environments should pass a real key via `Signer.local(pk)`. Use `with` blocks (or call `.close()`) to release native resources.
 
 ## Example — sponsored UserOp
 

--- a/docs/pages/get-started/sdks/server-side/rust.mdx
+++ b/docs/pages/get-started/sdks/server-side/rust.mdx
@@ -41,7 +41,7 @@ let signer = Signer::local(&private_key)?;
 let account = ctx.new_account(&signer, KernelVersion::V3_3, 0)?;
 ```
 
-`Signer::generate()` is useful for demos when you don't need to reuse a key. All handles implement `Drop` — native resources are released automatically.
+`Signer::generate()` is useful for demos when you don't need to reuse a key. It requires a working OS CSPRNG; on hardened sandboxes where `getrandom(2)` is blocked the call returns an error rather than producing a weak key, so production paths in those environments should pass a real key via `Signer::local(&pk)`. All handles implement `Drop` — native resources are released automatically.
 
 ## Example — sponsored UserOp
 


### PR DESCRIPTION
## Summary

A recent audit fix in `zerodev-omni-sdk` ([F-01 / ZER-737](https://linear.app/offchain-labs/issue/ZER-737)) tightened `Signer.generate()` so it returns an error instead of silently producing a weak key when the OS CSPRNG is unavailable. The realistic trigger is Linux containers running under a seccomp profile that blocks `getrandom(2)` (some Kubernetes / Docker / gVisor defaults).

This PR adds a one-sentence note on each affected SDK page so callers running in hardened environments know to pass a real key via the language's `Signer.local(…)` constructor instead of relying on `generate()`.

Pages updated:
- `client-side/ios.mdx`
- `client-side/android.mdx`
- `server-side/python.mdx`
- `server-side/rust.mdx`
- `server-side/go.mdx`

C docs (`server-side/c.mdx`) only reference `aa_signer_generate` inline in the 7702 example, not in prose — left unchanged.