### PR TITLE
fix(server): serve Vocs search index by allowing dotfiles in sirv

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -21,6 +21,10 @@ const assets = sirv(DIR, {
   etag: true,
   gzip: true,
   brotli: true,
+  // Vocs writes its search index to docs/dist/.vocs/search-index-<hash>.json and
+  // the client fetches it from /.vocs/...; sirv skips dot-directories unless this
+  // is set, which 404'd the index and broke site search.
+  dotfiles: true,
   setHeaders(res, pathname) {
     if (pathname.startsWith("/assets/")) {
       res.setHeader("cache-control", "public, max-age=31536000, immutable");


### PR DESCRIPTION
## What

Set `dotfiles: true` on the `assets` sirv instance in `server.mjs` so the Vocs search index is served.

## Why

Site search broke after the docs moved from a Render Static Site to the sirv-backed Node web service (#74, d358dc0).

- Vocs builds its search index to `docs/dist/.vocs/search-index-<hash>.json` and the client fetches it from `/.vocs/search-index-<hash>.json`.
- sirv's default `dotfiles: false` skips any path containing a dot-segment, so it never added the index to its file map.
- The request fell through `assets()` → `server.mjs` returned `404.html` → the browser's `.json()` parse threw → search silently failed.
- The old static site served the dot-directory fine, which is why this only surfaced after the hosting change. (Reported by Jayesh in #docs.)

## Verification

Confirmed end-to-end against a real production build (`vocs build`) served by the actual `server.mjs` (`sirv@3.0.2`, `vocs@1.0.1`):

| Path | sirv default (bug) | with `dotfiles: true` |
|---|---|---|
| `/.vocs/search-index-<hash>.json` | **404** | **200 `application/json`** — parses as MiniSearch (908 docs) |
| `/.vocs/icons/*.svg` (UI icons) | **404** | **200 `image/svg+xml`** |

Other routes unaffected: `/` → 200 HTML, `/assets/*` → 200 + immutable cache, clean URLs (`/get-started/quickstart`) → 200, exact redirect (`/sdk/getting-started/quickstart`) → 301, prefix redirect (`/magic-account/*`) → 301, SPA fallback (`/sdk/...`) → 200 shell, unknown path → 404.

## Security

`dotfiles: true` lets sirv serve dot-prefixed paths. Assessed as low risk; it restores the pre-regression production behavior:

- **Bounded to `docs/dist`.** The server root (`DIR = .../docs/dist`) sits below the repo root, so `.env`, `.git`, and source files are physically outside the served tree. Verified: requests for `/../.env`, `/../../.env`, `/.vocs/../../.env`, `/../server.mjs`, `/../redirects.config.js`, and URL-encoded variants (`%2e%2e`, `%2f`) all return **404** — sirv serves only files in its pre-built index of `docs/dist` and normalizes traversal away. `dotfiles: true` does not change traversal handling.
- **Only dot-path in the build is `.vocs/`** — the search index plus 4 UI SVG icons, all intended to be public. A full `find docs/dist -name '.*'` shows no `.env`, `.git`, sourcemaps, keys, or `.DS_Store`. This is the same data the previous Render Static Site already served (why search worked before), so this is parity, not new exposure.
- **`.well-known`** is served by sirv regardless of this flag — unchanged.
- **Residual/future risk:** if a future build step ever emits a sensitive dotfile *into `docs/dist`* (e.g. a stray `.env`, `.DS_Store`, or a dot-pathed sourcemap), the flag would serve it. None exist today and the build output is Vocs-controlled, so likelihood/impact is low. If we want to remove even that future risk, the tighter alternative is to keep `dotfiles: false` and add a dedicated `/.vocs/*` static handler scoped to that one directory.

## Reviewer notes

- One-line change plus a comment; no behavior change for redirects, assets, SPA fallback, or 404s.
- Requires a redeploy of the `docs-dynamic` Render service to take effect.
