### PR TITLE
docs(wallets): replace aaUrl with aaHost

### DIFF
--- a/docs/pages/wallets/auth/passkeys.mdx
+++ b/docs/pages/wallets/auth/passkeys.mdx
@@ -14,7 +14,7 @@ import { createConfig, http } from 'wagmi'
 import { arbitrumSepolia } from 'wagmi/chains'
 
 const projectId = '<your-project-id>'
-const aaUrl = '<your-chain-specific-zerodev-rpc-url>'
+const aaHost = 'https://rpc.zerodev.app'
 const chainRpcUrl = 'https://sepolia-rollup.arbitrum.io/rpc'
 
 export const config = createConfig({
@@ -22,7 +22,7 @@ export const config = createConfig({
   connectors: [
     zeroDevWallet({
       projectId,
-      aaUrl,
+      aaHost,
       chains: [arbitrumSepolia],
       mode: '7702',
     }),
@@ -42,7 +42,7 @@ By default, the SDK uses the current hostname. Set `rpId` when you want passkeys
 ```tsx
 zeroDevWallet({
   projectId,
-  aaUrl,
+  aaHost,
   chains: [arbitrumSepolia],
   rpId: 'example.com',
 })

--- a/docs/pages/wallets/auth/wallet-ui-kit.mdx
+++ b/docs/pages/wallets/auth/wallet-ui-kit.mdx
@@ -50,7 +50,7 @@ import { createConfig, http } from 'wagmi'
 import { arbitrumSepolia } from 'wagmi/chains'
 
 const projectId = '<your-project-id>'
-const aaUrl = '<your-chain-specific-zerodev-rpc-url>'
+const aaHost = 'https://rpc.zerodev.app'
 const chainRpcUrl = 'https://sepolia-rollup.arbitrum.io/rpc'
 
 export const config = createConfig({
@@ -58,7 +58,7 @@ export const config = createConfig({
   connectors: [
     zeroDevWallet({
       projectId,
-      aaUrl,
+      aaHost,
       chains: [arbitrumSepolia],
       mode: '7702',
       config: {
@@ -226,7 +226,7 @@ If you only want the prebuilt login UI, you can omit `SignatureRequest`. To forc
 ```tsx
 zeroDevWallet({
   projectId,
-  aaUrl,
+  aaHost,
   chains: [arbitrumSepolia],
   mode: '7702',
   config: {

--- a/docs/pages/wallets/quickstart.mdx
+++ b/docs/pages/wallets/quickstart.mdx
@@ -46,18 +46,18 @@ For example, if you run your app at `http://localhost:3000` during development, 
 
 ## Add configuration values
 
-In the ZeroDev dashboard, open your project and copy its project ID. Then open the network you enabled for this app and copy its Bundler RPC URL.
+In the ZeroDev dashboard, open your project and copy its project ID. Make sure the network you want to use is enabled for the project.
 
 Add these values to your app's configuration. The exact environment variable prefix depends on your framework:
 
 ```bash
 ZERODEV_PROJECT_ID="your-project-id"
-ZERODEV_AA_URL="your-chain-specific-zerodev-rpc-url"
+ZERODEV_AA_HOST="https://rpc.zerodev.app"
 ARBITRUM_SEPOLIA_RPC_URL="https://sepolia-rollup.arbitrum.io/rpc"
 ```
 
 - `ZERODEV_PROJECT_ID` is your ZeroDev project ID.
-- `ZERODEV_AA_URL` is the network-specific Bundler RPC URL from the dashboard.
+- `ZERODEV_AA_HOST` is the ZeroDev bundler and paymaster host. It is optional and defaults to `https://rpc.zerodev.app`; set it only when you target staging or self-hosted infrastructure. The SDK derives the per-chain URL from this host, so the same value works across every chain.
 - `ARBITRUM_SEPOLIA_RPC_URL` is the chain RPC used by Wagmi's transport.
 
 This example uses Arbitrum Sepolia. Replace the chain and RPC URLs if your project uses a different chain.
@@ -72,7 +72,7 @@ import { createConfig, http } from 'wagmi'
 import { arbitrumSepolia } from 'wagmi/chains'
 
 const projectId = '<your-project-id>'
-const aaUrl = '<your-chain-specific-zerodev-rpc-url>'
+const aaHost = 'https://rpc.zerodev.app'
 const chainRpcUrl = 'https://sepolia-rollup.arbitrum.io/rpc'
 
 export const config = createConfig({
@@ -80,7 +80,7 @@ export const config = createConfig({
   connectors: [
     zeroDevWallet({
       projectId,
-      aaUrl,
+      aaHost,
       chains: [arbitrumSepolia],
       mode: '7702',
     }),
@@ -276,7 +276,7 @@ The examples above use `@zerodev/wallet-react` so you can build your own UI. If 
 
 - **Allowlist errors**: confirm that the dashboard allowlists the exact origin you are opening in the browser.
 - **Sponsored transaction fails**: confirm that a gas policy exists for the project and chain.
-- **Wrong chain**: make sure the chain in `createConfig`, the `aaUrl`, and the gas policy all refer to the same chain.
+- **Wrong chain**: make sure the chain in `createConfig` and the gas policy refer to the same chain, and that the chain is enabled for the project. `aaHost` is host-only, so the SDK derives the correct per-chain URL automatically.
 
 ## Next steps
 

--- a/docs/pages/wallets/session-management.mdx
+++ b/docs/pages/wallets/session-management.mdx
@@ -21,11 +21,11 @@ import { zeroDevWallet } from '@zerodev/wallet-react'
 import { arbitrumSepolia } from 'wagmi/chains'
 
 const projectId = '<your-project-id>'
-const aaUrl = '<your-chain-specific-zerodev-rpc-url>'
+const aaHost = 'https://rpc.zerodev.app'
 
 zeroDevWallet({
   projectId,
-  aaUrl,
+  aaHost,
   chains: [arbitrumSepolia],
   autoRefreshSession: true,
   sessionWarningThreshold: 120_000,
@@ -90,7 +90,7 @@ import type { StorageAdapter } from '@zerodev/wallet-core'
 import { arbitrumSepolia } from 'wagmi/chains'
 
 const projectId = '<your-project-id>'
-const aaUrl = '<your-chain-specific-zerodev-rpc-url>'
+const aaHost = 'https://rpc.zerodev.app'
 
 const sessionStorageAdapter: StorageAdapter = {
   getItem: async (key) => window.sessionStorage.getItem(key),
@@ -100,7 +100,7 @@ const sessionStorageAdapter: StorageAdapter = {
 
 zeroDevWallet({
   projectId,
-  aaUrl,
+  aaHost,
   chains: [arbitrumSepolia],
   sessionStorage: sessionStorageAdapter,
 })


### PR DESCRIPTION
Stacked on top of #76 (`srinjoy/update-wallet-docs`) — base is that branch, not `main`.

Updates the wallet docs to match the SDK's `aaUrl` → `aaHost` change (zerodevapp/zerodev-wallet-sdk#282).

## Why
`aaUrl` was a full, **chain-specific** bundler RPC URL, so it pinned every chain to one endpoint — broken for multichain apps. It's replaced by `aaHost` (origin only): the SDK builds the per-chain URL itself (`${host}/api/${version}/${projectId}/chain/${chainId}`), so one value works across all chains and the API version is no longer baked into consumer config.

## What
- `const aaUrl = '<your-chain-specific-zerodev-rpc-url>'` → `const aaHost = 'https://rpc.zerodev.app'` and the `aaUrl,` → `aaHost,` connector props, across `quickstart`, `passkeys`, `wallet-ui-kit`, and `session-management`.
- Quickstart config section: `ZERODEV_AA_URL` → `ZERODEV_AA_HOST`; clarified it's **optional** (defaults to `https://rpc.zerodev.app`), host-only, and works across every chain. Dropped the "copy the network-specific Bundler RPC URL" step.
- Quickstart troubleshooting "Wrong chain" bullet no longer references `aaUrl` — `aaHost` is host-only, so per-chain URL derivation is automatic.

Pure rename + prose; no structural changes. Merge after #76.
