### PR TITLE
docs(wallets): fix stale OTP params, deprecated useGetUserEmail refs, magic-link keys

### DIFF
--- a/docs/pages/wallets/auth/email-otp.mdx
+++ b/docs/pages/wallets/auth/email-otp.mdx
@@ -115,7 +115,7 @@ export function EmailOTPLogin() {
 ## Notes
 
 - Keep the `otpId` and `otpEncryptionTargetBundle` on the client until verification completes. For a single-page flow, component state is enough.
-- The authenticated user's email is available through [`useGetUserEmail`](/wallets/hooks/use-get-user-email).
+- The authenticated user's email and linked login methods are available through `useAuthenticators`.
 - If you need link-based email login instead of manual code entry, use [Magic Link](/wallets/auth/magic-link).
 
 ## Next steps

--- a/docs/pages/wallets/auth/google-oauth.mdx
+++ b/docs/pages/wallets/auth/google-oauth.mdx
@@ -76,7 +76,7 @@ After the flow completes, use `useAccount`, `useSignMessage`, and `useSendTransa
 
 - Popup blockers can block OAuth if the mutation is not triggered directly from a user action.
 - The dashboard ACL allowlist must include the exact origin that opens the popup.
-- The authenticated user's email is available through [`useGetUserEmail`](/wallets/hooks/use-get-user-email).
+- The authenticated user's email and linked login methods are available through `useAuthenticators`.
 
 ## Next steps
 

--- a/docs/pages/wallets/auth/magic-link.mdx
+++ b/docs/pages/wallets/auth/magic-link.mdx
@@ -42,9 +42,9 @@ export function MagicLinkLogin() {
         onClick={async () => {
           const result = await sendMagicLink.mutateAsync({ email })
 
-          sessionStorage.setItem('zerodevMagicLinkOtpId', result.otpId)
+          sessionStorage.setItem('magicLinkOtpId', result.otpId)
           sessionStorage.setItem(
-            'zerodevMagicLinkBundle',
+            'magicLinkBundle',
             result.otpEncryptionTargetBundle,
           )
         }}
@@ -75,9 +75,9 @@ export function VerifyMagicLink() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const code = params.get('code')
-    const otpId = sessionStorage.getItem('zerodevMagicLinkOtpId')
+    const otpId = sessionStorage.getItem('magicLinkOtpId')
     const otpEncryptionTargetBundle = sessionStorage.getItem(
-      'zerodevMagicLinkBundle',
+      'magicLinkBundle',
     )
 
     if (

--- a/docs/pages/wallets/auth/wallet-ui-kit.mdx
+++ b/docs/pages/wallets/auth/wallet-ui-kit.mdx
@@ -23,29 +23,29 @@ This guide uses Arbitrum Sepolia and email OTP. Replace the chain, chain RPC URL
 :::code-group
 
 ```bash [npm]
-npm i @zerodev/react-wallet-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
+npm i @zerodev/wallet-react-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
 ```
 
 ```bash [yarn]
-yarn add @zerodev/react-wallet-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
+yarn add @zerodev/wallet-react-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
 ```
 
 ```bash [pnpm]
-pnpm i @zerodev/react-wallet-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
+pnpm i @zerodev/wallet-react-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
 ```
 
 ```bash [bun]
-bun add @zerodev/react-wallet-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
+bun add @zerodev/wallet-react-ui @zerodev/wallet-react @zerodev/wallet-core wagmi viem @tanstack/react-query
 ```
 
 :::
 
 ## Configure Wagmi
 
-Import `zeroDevWallet` from `@zerodev/react-wallet-ui`. This connector wraps the base ZeroDev Wallet connector and controls the kit's auth UI state.
+Import `zeroDevWallet` from `@zerodev/wallet-react-ui`. This connector wraps the base ZeroDev Wallet connector and controls the kit's auth UI state.
 
 ```tsx
-import { zeroDevWallet } from '@zerodev/react-wallet-ui'
+import { zeroDevWallet } from '@zerodev/wallet-react-ui'
 import { createConfig, http } from 'wagmi'
 import { arbitrumSepolia } from 'wagmi/chains'
 
@@ -83,7 +83,7 @@ Import the kit stylesheet once at your app entry, then wrap your app with Wagmi 
 
 ```tsx
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import '@zerodev/react-wallet-ui/styles.css'
+import '@zerodev/wallet-react-ui/styles.css'
 import type { ReactNode } from 'react'
 import { WagmiProvider } from 'wagmi'
 import { config } from './wagmi'
@@ -106,7 +106,7 @@ export function WalletProviders({ children }: { children: ReactNode }) {
 Call Wagmi's `connect` with the ZeroDev connector to start login. Render `<AuthFlow />` in the same provider tree; it displays the active auth screen while the connector waits for the user to finish authentication.
 
 ```tsx
-import { AuthFlow } from '@zerodev/react-wallet-ui'
+import { AuthFlow } from '@zerodev/wallet-react-ui'
 import { useAccount, useConnect, useDisconnect } from 'wagmi'
 
 export function WalletLogin() {
@@ -189,7 +189,7 @@ Import the kit stylesheet once, and make sure your app's global CSS does not bro
 The UI Kit also includes `SignatureRequest`, an experimental confirmation screen for signature signing and transaction requests that is currently in beta. Mount it once in the same provider tree as your wallet UI.
 
 ```tsx
-import { AuthFlow, SignatureRequest } from '@zerodev/react-wallet-ui'
+import { AuthFlow, SignatureRequest } from '@zerodev/wallet-react-ui'
 
 export function WalletOverlays() {
   return (

--- a/docs/pages/wallets/hooks/use-send-otp.mdx
+++ b/docs/pages/wallets/hooks/use-send-otp.mdx
@@ -29,8 +29,7 @@ function SendCode() {
       <button
         onClick={async () => {
           const result = await sendOTP.mutateAsync({ email })
-          console.log('OTP ID:', result.otpId)
-          // Pass otpId to useVerifyOTP
+          // Pass result.otpId and result.otpEncryptionTargetBundle to useVerifyOTP
         }}
         disabled={sendOTP.isPending || !email}
       >
@@ -49,37 +48,25 @@ function SendCode() {
 
 **Required.** The email address to send the verification code to.
 
-### emailCustomization
-
-`{ magicLinkTemplate?: string } | undefined`
-
-Optional email customization options.
-
-#### magicLinkTemplate
-
-`string | undefined`
-
-Custom template for the email content.
-
 ## Return Types
 
 [TanStack Query mutation docs](https://tanstack.com/query/v5/docs/react/reference/useMutation)
 
 ### mutate
 
-`(variables: { email: string; emailCustomization?: { magicLinkTemplate?: string } }) => void`
+`(variables: { email: string }) => void`
 
 The mutation function to send the OTP.
 
 ### mutateAsync
 
-`(variables: { email: string; emailCustomization?: { magicLinkTemplate?: string } }) => Promise<{ otpId: string }>`
+`(variables: { email: string }) => Promise<{ otpId: string; otpEncryptionTargetBundle: string }>`
 
 Similar to [`mutate`](#mutate) but returns a promise.
 
 ### data
 
-`{ otpId: string } | undefined`
+`{ otpId: string; otpEncryptionTargetBundle: string } | undefined`
 
 - Defaults to `undefined`
 - The data returned from the mutation on success.
@@ -89,5 +76,11 @@ Similar to [`mutate`](#mutate) but returns a promise.
 `string`
 
 The identifier for this OTP verification attempt. Pass this to [`useVerifyOTP`](/wallets/hooks/use-verify-otp) to complete authentication.
+
+#### otpEncryptionTargetBundle
+
+`string`
+
+The encryption target bundle for this OTP verification. Store this value with `otpId` and pass both to [`useVerifyOTP`](/wallets/hooks/use-verify-otp).
 
 <MutationResult />


### PR DESCRIPTION
Stacked on top of #76 (`srinjoy/update-wallet-docs`) — base is that branch, not `main`.

Small, decision-free accuracy fixes found while reviewing #76. Verified against the SDK source.

## Changes
- **`use-send-otp.mdx`** — remove the `emailCustomization` / `magicLinkTemplate` parameter (it no longer exists in the SDK; `sendOTP` takes `{ email }` only), and add the `otpEncryptionTargetBundle` return value that the hook actually returns (the OTP guide already uses it, and `useVerifyOTP` requires it). Return type now matches `use-send-magic-link.mdx`.
- **`email-otp.mdx`, `google-oauth.mdx`** — the inline "email is available through `useGetUserEmail`" bullets pointed at a deprecated hook (per the review thread on the hook page). Reworded to `useAuthenticators` as inline code (no link, since that reference page isn't added yet — andras is adding it).
- **`magic-link.mdx`** — align the `sessionStorage` keys (`zerodevMagicLinkOtpId`/`zerodevMagicLinkBundle` → `magicLinkOtpId`/`magicLinkBundle`) so they match `use-send-magic-link.mdx` and `use-verify-magic-link.mdx`.

## Deliberately excluded (need a decision, not mechanical)
- Package name `@zerodev/react-wallet-ui` vs the SDK rename to `@zerodev/wallet-react-ui` (PR zerodevapp/zerodev-wallet-sdk#286) — pick the final published name first.
- Orphaned hook reference pages after the "Hooks" sidebar section was removed — delete vs keep-in-nav (interacts with adding a `useAuthenticators` page).
- Removal of the "Alpha Wallets / internal testing only" banners — product/legal call.
