### PR TITLE
docs(omni-sdk): update newAccount snippets for optional address param

### DIFF
--- a/docs/pages/get-started/sdks/server-side/c.mdx
+++ b/docs/pages/get-started/sdks/server-side/c.mdx
@@ -49,7 +49,7 @@ aa_signer_t *signer;
 aa_signer_local(private_key, &signer);
 
 aa_account_t *account;
-aa_account_create(ctx, signer, AA_KERNEL_V3_3, 0 /* index */, &account);
+aa_account_create(ctx, signer, AA_KERNEL_V3_3, 0 /* index */, NULL /* address */, &account);
 ```
 
 ## Example — sponsored UserOp
@@ -69,7 +69,7 @@ int main(void) {
     aa_signer_local(private_key, &signer);
 
     aa_account_t *account;
-    aa_account_create(ctx, signer, AA_KERNEL_V3_3, 0, &account);
+    aa_account_create(ctx, signer, AA_KERNEL_V3_3, 0, NULL /* address */, &account);
 
     uint8_t recipient[20] = { /* ... */ };
     aa_call_t call = { 0 };

--- a/docs/pages/get-started/sdks/server-side/go.mdx
+++ b/docs/pages/get-started/sdks/server-side/go.mdx
@@ -45,7 +45,7 @@ signer, err := aa.LocalSigner(privateKey)
 if err != nil { panic(err) }
 defer signer.Close()
 
-account, err := ctx.NewAccount(signer, aa.KernelV3_3, 0)
+account, err := ctx.NewAccount(signer, aa.KernelV3_3, 0, nil)
 if err != nil { panic(err) }
 defer account.Close()
 ```
@@ -74,7 +74,7 @@ func main() {
     signer, _ := aa.LocalSigner(privateKey)
     defer signer.Close()
 
-    account, _ := ctx.NewAccount(signer, aa.KernelV3_3, 0)
+    account, _ := ctx.NewAccount(signer, aa.KernelV3_3, 0, nil)
     defer account.Close()
 
     recipient := [20]byte{ /* ... */ }

--- a/docs/pages/get-started/sdks/server-side/rust.mdx
+++ b/docs/pages/get-started/sdks/server-side/rust.mdx
@@ -38,7 +38,7 @@ let ctx = Context::new(
     PaymasterMiddleware::ZeroDev,
 )?;
 let signer = Signer::local(&private_key)?;
-let account = ctx.new_account(&signer, KernelVersion::V3_3, 0)?;
+let account = ctx.new_account(&signer, KernelVersion::V3_3, 0, None)?;
 ```
 
 `Signer::generate()` is useful for demos when you don't need to reuse a key. It requires a working OS CSPRNG; on hardened sandboxes where `getrandom(2)` is blocked the call returns an error rather than producing a weak key, so production paths in those environments should pass a real key via `Signer::local(&pk)`. All handles implement `Drop` — native resources are released automatically.
@@ -51,7 +51,7 @@ use zerodev_aa::{Context, Signer, Call, KernelVersion, GasMiddleware, PaymasterM
 let ctx = Context::new(project_id, "", "", 11155111,
     GasMiddleware::ZeroDev, PaymasterMiddleware::ZeroDev)?;
 let signer = Signer::local(&private_key)?;
-let account = ctx.new_account(&signer, KernelVersion::V3_3, 0)?;
+let account = ctx.new_account(&signer, KernelVersion::V3_3, 0, None)?;
 
 let recipient = /* 20-byte address */;
 let hash = account.send_user_op(&[Call {


### PR DESCRIPTION
## Summary

Follow-up to [zerodev-omni-sdk PR #33](https://github.com/zerodevapp/zerodev-omni-sdk/pull/33), which adds an optional \`address\` param to \`newAccount\` for kernel-version migrations (v3.1 → v3.3, address stays fixed).

Rust / Go / C have no default arguments, so the param is required at every call site. The existing SDK docs snippets omit it and will stop compiling once the release ships. Pass \`None\` / \`nil\` / \`NULL\` to keep the counterfactual CREATE2 behavior.

Python / Swift / Kotlin default to \`null\` and remain source-compatible — those pages are left untouched.

## Changes

- \`server-side/c.mdx\` — 2 snippets updated with \`NULL /* address */\`
- \`server-side/go.mdx\` — 2 snippets updated with \`, nil\`
- \`server-side/rust.mdx\` — 2 snippets updated with \`, None\`

## Not included

Documentation for the *new* address-pinning capability (migration guide). Client is on TS SDK for the on-chain upgrade half; separate follow-up if we decide to write a formal migration walkthrough.