### PR TITLE
fix: redirect /blog to www.zerodev.app/blog

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -14,8 +14,11 @@ const PORT = Number(process.env.PORT) || 10000;
 const DIR = join(fileURLToPath(new URL(".", import.meta.url)), "docs", "dist");
 
 const EXACT = new Map(redirects.map((r) => [r.from, r.to]));
-const PREFIX = [["/magic-account", "/smart-accounts/chain-abstraction/overview"]];
-const SPA_FALLBACK = ["/sdk", "/meta-infra", "/recovery-flow", "/blog", "/react", "/smart-wallet"];
+const PREFIX = [
+  ["/magic-account", "/smart-accounts/chain-abstraction/overview"],
+  ["/blog", "https://www.zerodev.app/blog"],
+];
+const SPA_FALLBACK = ["/sdk", "/meta-infra", "/recovery-flow", "/react", "/smart-wallet"];
 
 const assets = sirv(DIR, {
   etag: true,


### PR DESCRIPTION
`docs.zerodev.app/blog` duplicates the website blog and still gets organic search traffic. This 301s /blog and everything under it to https://www.zerodev.app/blog.

Post slugs differ between the two blogs, so all paths go to the blog index rather than guessing per-post mappings. Verified locally: /blog, /blog/, and /blog/anything all return 301 with the query string preserved.

Part of [ZER-906](https://linear.app/offchain-labs/issue/ZER-906/add-redirects-for-old-docs-and-blog)